### PR TITLE
add failing cookie test

### DIFF
--- a/test/bones/http/handlers_test.clj
+++ b/test/bones/http/handlers_test.clj
@@ -195,16 +195,17 @@
       (is (= "{:message \"query params not valid\", :data {:q missing-required-key, :something disallowed-key}}" (:body response)))
       (is (= 400 (:status response))))))
 
+(defn parse-cookie [cookie]
+  (-> cookie
+      first
+      (clojure.string/split #";")
+      first))
+
 (deftest session-requests
   (let [login-response (login-post valid-login)
         cookie (get-in login-response [:headers "Set-Cookie"])]
-    (testing "command with session"
-      (let [session (second (re-matches #".*\=(.*)" (first (clojure.string/split (first cookie) #";"))))
-            body-params {:command :echo :args {:who "mr teapot"}}
-            ;; decode the cookie first, like a browser does
-            cookie-header {(get-in conf [:http/auth :cookie-name])
-                           (codec/form-decode-str session)}
-            response (edn-post body-params {"cookie" cookie})
-            ]
+    (testing "command with session - reuse the cookie"
+      (let [body-params {:command :echo :args {:who "mr teapot"}}
+            response (edn-post body-params {"cookie" (parse-cookie cookie)})]
         (is (= "{:who \"mr teapot\"}" (:body response)))
         (is (= 200 (:status response)))))))


### PR DESCRIPTION
Something is wrong here. It looks like a cookie is not able to be used. I've seen this in the browser too, where a login is successful, but all subsequent requests fail with a "Not Authenticated" error response.
